### PR TITLE
Return minimum `ConsultationDate` by `CodedEvent_ID`

### DIFF
--- a/analysis/coded_event_id/query.sql
+++ b/analysis/coded_event_id/query.sql
@@ -1,4 +1,4 @@
--- Are values of CodedEvent_ID valid CTV3 codes?
+-- Return some basic information about values of the CodedEvent_ID column.
 SELECT
     CodedEvent_ID AS ctv3_code,
     Description AS ctv3_description,

--- a/analysis/coded_event_id/query.sql
+++ b/analysis/coded_event_id/query.sql
@@ -1,7 +1,7 @@
 -- Are values of CodedEvent_ID valid CTV3 codes?
 SELECT
-    CodedEvent_ID AS coded_event_id,
-    Description AS description,
+    CodedEvent_ID AS ctv3_code,
+    Description AS ctv3_description,
     MIN(ConsultationDate) AS min_consultation_date
 FROM OpenPROMPT LEFT JOIN CTV3Dictionary ON CodedEvent_ID = CTV3Code
 GROUP BY CodedEvent_ID, Description

--- a/analysis/coded_event_id/query.sql
+++ b/analysis/coded_event_id/query.sql
@@ -1,6 +1,8 @@
 -- Are values of CodedEvent_ID valid CTV3 codes?
-SELECT DISTINCT
+SELECT
     CodedEvent_ID AS coded_event_id,
-    Description AS description
+    Description AS description,
+    MIN(ConsultationDate) AS min_consultation_date
 FROM OpenPROMPT LEFT JOIN CTV3Dictionary ON CodedEvent_ID = CTV3Code
+GROUP BY CodedEvent_ID, Description
 ORDER BY CodedEvent_ID


### PR DESCRIPTION
As requested, @hendersonad!

To make things slightly easier, we use column names from the ehrQL table (`open_prompt`) rather than from the database table (`OpenPROMPT`).